### PR TITLE
fixed post_notification CGI unescape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ doc/
 
 #MACOSX artifacts
 .DS_Store
+
+#rubymine
+.idea/
+

--- a/lib/mundipagg/post_notification.rb
+++ b/lib/mundipagg/post_notification.rb
@@ -10,22 +10,13 @@ module Mundipagg
 	    # @return [Hash<Symbol, String>] A hash collection containing the XML data parsed.
 		def self.ParseNotification(xml)
 
-			nori = Nori.new(:convert_tags_to => lambda { |tag| PostNotification.to_underscore(tag).to_sym })
-			xml_hash  = nori.parse(CGI::unescapeHTML(xml))
+			nori = Nori.new(:convert_tags_to => lambda { |tag| tag.snakecase.to_sym })
+			first_pass = CGI::unescape(xml)
+			xml_hash  = nori.parse(CGI::unescapeHTML(first_pass))
 
 			return xml_hash
 		end
 
-		# Converts a string in Camel Case format to lower case with underscore.
-		#
-		# @param Example: 'StatusNotification' outputs 'status_notification'
-		# @returns [String] lower case string separated with underscore
-		def self.to_underscore(camel_case_string)
-			return camel_case_string.gsub(/::/, '/').
-				gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-				gsub(/([a-z\d])([A-Z])/,'\1_\2').
-				tr("-", "_").
-				downcase
-		end
+
 	end
 end


### PR DESCRIPTION
Mundipagg::PostNotification.ParseNotification was returning empty. I fixed passing the string twice through the CGI method. Once CGI::unescape and a second time CGI::unescapeHTML. Its also possible to use this gem: 'owasp-esapi-ruby' to convert the mixed encoded to XML, but Id rather the CGI standard one. Please, check this out.